### PR TITLE
solved the profile issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,7 +180,7 @@ DEPENDENCIES
   bootsnap
   debug
   faker
-  jwt (~> 2.7)
+  jwt
   puma (~> 5.0)
   rack-cors
   rails (~> 7.0.5)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,7 +23,7 @@ end
 def current_user
     if decoded_token
         user_id = decoded_token[0]['user_id']
-        @user = User.find_by(id: user.id)
+        @user = User.find_by(id: user_id)
     end
 end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,15 +1,15 @@
 class UsersController < ApplicationController
 skip_before_action :authorized, only: [:create]
 
-# def profile
-#   render json: user
-# end
 def profile
-  @user = User.find(params[:id])
-  render json: { user: @user }, status: :ok
-rescue ActiveRecord::RecordNotFound
-  render json: { error: 'User not found' }, status: :not_found
+  render json: @user
 end
+# def profile
+#   @user = User.find(params[:id])
+#   render json: { user: @user }, status: :ok
+# rescue ActiveRecord::RecordNotFound
+#   render json: { error: 'User not found' }, status: :not_found
+# end
 
 
 def create


### PR DESCRIPTION
Removed double auth in the profile method.
`def profile
  @user = User.find(params[:id])
  render json: { user: @user }, status: :ok
rescue ActiveRecord::RecordNotFound
  render json: { error: 'User not found' }, status: :not_found
end`

This caused the error user not found to appear but when using the profile the maiin thing was to just access the previously logged in user which was accessed using the Auser in the current _user method. A simple render to json solved the bug